### PR TITLE
Update port and tls in route

### DIFF
--- a/deployments/3-helloworld-route.yaml
+++ b/deployments/3-helloworld-route.yaml
@@ -21,7 +21,9 @@ metadata:
 spec:
   path: "/helloworld"
   port:
-    targetPort: 8080
+    targetPort: 8080-tcp
+  tls:
+    termination: edge
   to:
     kind: Service
     name: helloworld-svc


### PR DESCRIPTION
- update targetPort to get rid of warning in openshift console about it not being a string
- add tls so the route is "secure". This gets it working in our default wireguard config. 
