### PR TITLE
Add TLS info to sample route

### DIFF
--- a/deployments/3-helloworld-route.yaml
+++ b/deployments/3-helloworld-route.yaml
@@ -21,7 +21,9 @@ metadata:
 spec:
   path: "/helloworld"
   port:
-    targetPort: 8080
+    targetPort: 8080-tcp
+  tls:
+    termination: edge
   to:
     kind: Service
     name: helloworld-svc

--- a/deployments/3-helloworld-route.yaml
+++ b/deployments/3-helloworld-route.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   path: "/helloworld"
   port:
-    targetPort: 8080-tcp
+    targetPort: 8080
   tls:
     termination: edge
   to:


### PR DESCRIPTION
Add TLS info so sample works with our default wireguard config

tested with Satellite cluster w/ wireguard and a regular ROKS cluster w/ public endpoints.