### PR TITLE
Add TLS Edge termination to the route

### DIFF
--- a/deployments/helloworld-route.yaml
+++ b/deployments/helloworld-route.yaml
@@ -9,6 +9,8 @@ spec:
   path: "/helloworld"
   port:
     targetPort: 8080
+  tls:
+    termination: edge
   to:
     kind: Service
     name: helloworld-svc


### PR DESCRIPTION
Add edge termination to make TLS termination at the router before forwarding the traffic to pods. Otherwise, route is not opening in private environment.